### PR TITLE
Python 3.x Support

### DIFF
--- a/anora/templatetags/anora.py
+++ b/anora/templatetags/anora.py
@@ -1,17 +1,14 @@
 import re
 
 from django import template
-from django.conf import settings
-from django.utils.encoding import force_unicode
-from django.template.defaultfilters import stringfilter
 
 register = template.Library()
 
-CONSONANT_SOUND = re.compile(r'''one(![ir])''', re.IGNORECASE|re.VERBOSE)
-VOWEL_SOUND = re.compile(r'''[aeio]|u([aeiou]|[^n][^aeiou]|ni[^dmnl]|nil[^l])|h(ier|onest|onou?r|ors\b|our(!i))|[fhlmnrsx]\b''', re.IGNORECASE|re.VERBOSE)
+CONSONANT_SOUND = re.compile(r'''one(![ir])''', re.IGNORECASE | re.VERBOSE)
+VOWEL_SOUND = re.compile(r'''[aeio]|u([aeiou]|[^n][^aeiou]|ni[^dmnl]|nil[^l])|h(ier|onest|onou?r|ors\b|our(!i))|[fhlmnrsx]\b''', re.IGNORECASE | re.VERBOSE)
+
 
 @register.filter
 def anora(text):
-    text = force_unicode(text)
-    anora = 'an' if not CONSONANT_SOUND.match(text) and VOWEL_SOUND.match(text) else 'a'
-    return anora + ' ' + text
+	anora = 'an' if not CONSONANT_SOUND.match(text) and VOWEL_SOUND.match(text) else 'a'
+	return anora + ' ' + text

--- a/anora/tests.py
+++ b/anora/tests.py
@@ -1,8 +1,9 @@
 from django.utils import unittest
 from anora.templatetags.anora import anora
 
-class AnoraTestCase(unittest.TestCase):
 
+class AnoraTestCase(unittest.TestCase):
+	
 	def test_anora(self):
 		awords = ['rabbit', 'mole', 'fox']
 		anwords = ['owl', 'ox', 'octopus']


### PR DESCRIPTION
Python 3.x Support (force_unicode only works in Python 2.x)
Django 1.6+ Support (force_unicode is deprecated)
Removed unused imports
